### PR TITLE
feat: Timesheet (JSON + PDF) and Reports endpoints

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -98,6 +98,13 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- PDF generation for timesheet export -->
+        <dependency>
+            <groupId>com.github.librepdf</groupId>
+            <artifactId>openpdf</artifactId>
+            <version>1.3.32</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend/src/main/java/com/petsaudedigital/backend/api/ReportsController.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/api/ReportsController.java
@@ -1,0 +1,25 @@
+package com.petsaudedigital.backend.api;
+
+import com.petsaudedigital.backend.api.dto.ReportDtos;
+import com.petsaudedigital.backend.service.ReportsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class ReportsController {
+    private final ReportsService reportsService;
+
+    @GetMapping("/api/v1/reports/hours-by-user")
+    public ResponseEntity<ReportDtos.HoursByUser> hoursByUser(@RequestParam Long gtId,
+                                                              @RequestParam String month) {
+        return ResponseEntity.ok(reportsService.hoursByUser(gtId, month));
+    }
+
+    @GetMapping("/api/v1/reports/pending-attendances")
+    public ResponseEntity<ReportDtos.PendingAttendances> pending(@RequestParam Long gtId) {
+        return ResponseEntity.ok(reportsService.pendingAttendances(gtId));
+    }
+}
+

--- a/backend/src/main/java/com/petsaudedigital/backend/api/TimesheetController.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/api/TimesheetController.java
@@ -1,0 +1,34 @@
+package com.petsaudedigital.backend.api;
+
+import com.petsaudedigital.backend.api.dto.TimesheetDtos;
+import com.petsaudedigital.backend.service.TimesheetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class TimesheetController {
+    private final TimesheetService timesheetService;
+
+    @GetMapping("/api/v1/users/{userId}/timesheet")
+    public ResponseEntity<TimesheetDtos.Summary> getTimesheet(@PathVariable Long userId,
+                                                              @RequestParam String from,
+                                                              @RequestParam String to) {
+        return ResponseEntity.ok(timesheetService.compute(userId, from, to));
+    }
+
+    @PostMapping("/api/v1/users/{userId}/timesheet/pdf")
+    public ResponseEntity<byte[]> getTimesheetPdf(@PathVariable Long userId,
+                                                  @RequestParam String from,
+                                                  @RequestParam String to) {
+        byte[] pdf = timesheetService.generatePdf(userId, from, to);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=timesheet-" + userId + ".pdf")
+                .contentType(MediaType.APPLICATION_PDF)
+                .body(pdf);
+    }
+}
+

--- a/backend/src/main/java/com/petsaudedigital/backend/api/dto/ReportDtos.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/api/dto/ReportDtos.java
@@ -1,0 +1,10 @@
+package com.petsaudedigital.backend.api.dto;
+
+import java.util.List;
+
+public class ReportDtos {
+    public record HoursByUserItem(Long userId, String email, double horas) {}
+    public record HoursByUser(List<HoursByUserItem> itens) {}
+    public record PendingItem(Long attendanceId, Long activityId, String titulo, Long userId, String email, String data, String inicio, String fim) {}
+    public record PendingAttendances(List<PendingItem> itens) {}
+}

--- a/backend/src/main/java/com/petsaudedigital/backend/api/dto/TimesheetDtos.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/api/dto/TimesheetDtos.java
@@ -1,0 +1,9 @@
+package com.petsaudedigital.backend.api.dto;
+
+import java.util.List;
+
+public class TimesheetDtos {
+    public record Item(Long activityId, String data, String inicio, String fim, long minutos) {}
+    public record Summary(long totalMinutos, double totalHoras, boolean horasInsuficientes, List<Item> itens) {}
+}
+

--- a/backend/src/main/java/com/petsaudedigital/backend/repository/AttendanceRepository.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/repository/AttendanceRepository.java
@@ -4,6 +4,8 @@ import com.petsaudedigital.backend.domain.Activity;
 import com.petsaudedigital.backend.domain.Attendance;
 import com.petsaudedigital.backend.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,5 +13,13 @@ import java.util.Optional;
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
     Optional<Attendance> findByActivityAndUser(Activity activity, User user);
     List<Attendance> findByActivity(Activity activity);
-}
 
+    @Query("select a from Attendance a where a.user.id = :userId and a.activity.data between :from and :to")
+    List<Attendance> findByUserAndDateRange(@Param("userId") Long userId, @Param("from") String from, @Param("to") String to);
+
+    @Query("select a from Attendance a where a.activity.gt.id = :gtId and a.activity.data between :from and :to")
+    List<Attendance> findByGtAndDateRange(@Param("gtId") Long gtId, @Param("from") String from, @Param("to") String to);
+
+    @Query("select a from Attendance a where a.activity.gt.id = :gtId and a.status = 'pendente'")
+    List<Attendance> findPendingByGt(@Param("gtId") Long gtId);
+}

--- a/backend/src/main/java/com/petsaudedigital/backend/service/ReportsService.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/service/ReportsService.java
@@ -1,0 +1,56 @@
+package com.petsaudedigital.backend.service;
+
+import com.petsaudedigital.backend.api.dto.ReportDtos;
+import com.petsaudedigital.backend.domain.Attendance;
+import com.petsaudedigital.backend.domain.enums.AttendanceStatus;
+import com.petsaudedigital.backend.repository.AttendanceRepository;
+import com.petsaudedigital.backend.repository.UserGtRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalTime;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class ReportsService {
+    private final AttendanceRepository attendanceRepository;
+    private final UserGtRepository userGtRepository;
+
+    public ReportDtos.HoursByUser hoursByUser(Long gtId, String month) {
+        // month format: YYYY-MM — compute [YYYY-MM-01, YYYY-MM-31] conservatively
+        String from = month + "-01";
+        String to = month + "-31";
+        List<Attendance> list = attendanceRepository.findByGtAndDateRange(gtId, from, to);
+        Map<Long, Double> hours = new HashMap<>();
+        Map<Long, String> emails = new HashMap<>();
+        for (Attendance a : list) {
+            if (a.getStatus() != AttendanceStatus.validada) continue;
+            long min = minutes(a);
+            hours.merge(a.getUser().getId(), min / 60.0, Double::sum);
+            emails.putIfAbsent(a.getUser().getId(), a.getUser().getEmail());
+        }
+        List<ReportDtos.HoursByUserItem> items = hours.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(e -> new ReportDtos.HoursByUserItem(e.getKey(), emails.get(e.getKey()), Math.round(e.getValue() * 100.0) / 100.0))
+                .toList();
+        return new ReportDtos.HoursByUser(items);
+    }
+
+    public ReportDtos.PendingAttendances pendingAttendances(Long gtId) {
+        List<Attendance> pend = attendanceRepository.findPendingByGt(gtId);
+        List<ReportDtos.PendingItem> items = pend.stream()
+                .map(a -> new ReportDtos.PendingItem(
+                        a.getId(), a.getActivity().getId(), a.getActivity().getTitulo(), a.getUser().getId(), a.getUser().getEmail(),
+                        a.getActivity().getData(), a.getActivity().getInicio(), a.getActivity().getFim()))
+                .toList();
+        return new ReportDtos.PendingAttendances(items);
+    }
+
+    private long minutes(Attendance a) {
+        LocalTime i = LocalTime.parse(a.getActivity().getInicio());
+        LocalTime f = LocalTime.parse(a.getActivity().getFim());
+        return Duration.between(i, f).toMinutes();
+    }
+}

--- a/backend/src/main/java/com/petsaudedigital/backend/service/TimesheetService.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/service/TimesheetService.java
@@ -1,0 +1,74 @@
+package com.petsaudedigital.backend.service;
+
+import com.lowagie.text.Document;
+import com.lowagie.text.PageSize;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.pdf.PdfWriter;
+import com.petsaudedigital.backend.api.dto.TimesheetDtos;
+import com.petsaudedigital.backend.domain.Attendance;
+import com.petsaudedigital.backend.domain.enums.AttendanceStatus;
+import com.petsaudedigital.backend.repository.AttendanceRepository;
+import com.petsaudedigital.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.time.Duration;
+import java.time.LocalTime;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TimesheetService {
+    private final AttendanceRepository attendanceRepository;
+    private final UserRepository userRepository;
+
+    public TimesheetDtos.Summary compute(Long userId, String from, String to) {
+        userRepository.findById(userId).orElseThrow();
+        List<Attendance> all = attendanceRepository.findByUserAndDateRange(userId, from, to);
+        List<Attendance> valids = all.stream().filter(a -> a.getStatus() == AttendanceStatus.validada).toList();
+        List<TimesheetDtos.Item> itens = valids.stream()
+                .sorted(Comparator.comparing(a -> a.getActivity().getData()))
+                .map(a -> {
+                    long min = minutes(a);
+                    return new TimesheetDtos.Item(a.getActivity().getId(), a.getActivity().getData(), a.getActivity().getInicio(), a.getActivity().getFim(), min);
+                }).toList();
+        long totalMin = itens.stream().mapToLong(TimesheetDtos.Item::minutos).sum();
+        double horas = Math.round((totalMin / 60.0) * 100.0) / 100.0;
+        boolean insuf = horas < 32.0; // padrão do SPEC
+        return new TimesheetDtos.Summary(totalMin, horas, insuf, itens);
+    }
+
+    public byte[] generatePdf(Long userId, String from, String to) {
+        var user = userRepository.findById(userId).orElseThrow();
+        TimesheetDtos.Summary s = compute(userId, from, to);
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            Document doc = new Document(PageSize.A4);
+            PdfWriter.getInstance(doc, baos);
+            doc.open();
+            doc.add(new Paragraph("Folha de Frequência"));
+            doc.add(new Paragraph("Usuário: " + user.getNome() + " (" + user.getEmail() + ")"));
+            doc.add(new Paragraph("Período: " + from + " a " + to));
+            doc.add(new Paragraph(String.format("Total: %.2f horas (insuficiente: %s)", s.totalHoras(), s.horasInsuficientes())));
+            doc.add(new Paragraph("Itens:"));
+            for (var it : s.itens()) {
+                doc.add(new Paragraph(String.format("#%d %s %s-%s (%d min)", it.activityId(), it.data(), it.inicio(), it.fim(), it.minutos())));
+            }
+            doc.add(new Paragraph("\nAssinatura do Bolsista: ________________________________"));
+            doc.add(new Paragraph("Assinatura do Coordenador/Tutor: _______________________"));
+            doc.close();
+            return baos.toByteArray();
+        } catch (Exception e) {
+            throw new IllegalStateException("Erro ao gerar PDF", e);
+        }
+    }
+
+    private long minutes(Attendance a) {
+        LocalTime i = LocalTime.parse(a.getActivity().getInicio());
+        LocalTime f = LocalTime.parse(a.getActivity().getFim());
+        return Duration.between(i, f).toMinutes();
+    }
+}
+

--- a/backend/src/test/java/com/petsaudedigital/backend/api/TimesheetReportsWebMvcTest.java
+++ b/backend/src/test/java/com/petsaudedigital/backend/api/TimesheetReportsWebMvcTest.java
@@ -1,0 +1,119 @@
+package com.petsaudedigital.backend.api;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.petsaudedigital.backend.domain.*;
+import com.petsaudedigital.backend.domain.enums.ActivityType;
+import com.petsaudedigital.backend.domain.enums.AttendanceMode;
+import com.petsaudedigital.backend.domain.enums.AttendanceStatus;
+import com.petsaudedigital.backend.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@org.springframework.security.test.context.support.WithMockUser(username = "admin@example.com", roles = {"coordenador_geral"})
+class TimesheetReportsWebMvcTest {
+
+    @Autowired MockMvc mvc;
+    @Autowired ObjectMapper om;
+
+    @Autowired ProjectRepository projectRepository;
+    @Autowired AxisRepository axisRepository;
+    @Autowired GtRepository gtRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired AttendanceRepository attendanceRepository;
+    @Autowired ActivityRepository activityRepository;
+
+    Long gtId; Long userId;
+
+    @BeforeEach
+    void setup() {
+        attendanceRepository.deleteAll();
+        activityRepository.deleteAll();
+        gtRepository.deleteAll();
+        axisRepository.deleteAll();
+        projectRepository.deleteAll();
+        userRepository.deleteAll();
+
+        User u = new User();
+        u.setNome("Aluno");
+        u.setEmail("aluno@example.com");
+        u.setPasswordHash("x");
+        userRepository.save(u);
+        userId = u.getId();
+
+        Project p = new Project();
+        p.setNome("P"); p.setDescricao("D"); p.setAtivo(1); p.setCreatedAt("2025-09-07T00:00:00");
+        projectRepository.save(p);
+        Axis a = new Axis(); a.setProject(p); a.setNome("Eixo"); a.setAtivo(1); axisRepository.save(a);
+        Gt gt = new Gt(); gt.setProject(p); gt.setAxis(a); gt.setNome("GT"); gt.setAtivo(1); gtRepository.save(gt); gtId = gt.getId();
+
+        Activity act1 = new Activity();
+        act1.setProject(p); act1.setGt(gt); act1.setTipo(ActivityType.individual);
+        act1.setTitulo("A1"); act1.setData("2025-09-05"); act1.setInicio("09:00"); act1.setFim("11:00"); act1.setCreatedBy(u);
+        activityRepository.save(act1);
+        Attendance att1 = new Attendance(); att1.setActivity(act1); att1.setUser(u); att1.setStatus(AttendanceStatus.validada); att1.setModo(AttendanceMode.manual); att1.setCreatedAt("2025-09-05T11:00:00");
+        attendanceRepository.save(att1);
+
+        Activity act2 = new Activity();
+        act2.setProject(p); act2.setGt(gt); act2.setTipo(ActivityType.individual);
+        act2.setTitulo("A2"); act2.setData("2025-09-10"); act2.setInicio("10:00"); act2.setFim("12:30"); act2.setCreatedBy(u);
+        activityRepository.save(act2);
+        Attendance att2 = new Attendance(); att2.setActivity(act2); att2.setUser(u); att2.setStatus(AttendanceStatus.validada); att2.setModo(AttendanceMode.manual); att2.setCreatedAt("2025-09-10T12:30:00");
+        attendanceRepository.save(att2);
+
+        Activity act3 = new Activity();
+        act3.setProject(p); act3.setGt(gt); act3.setTipo(ActivityType.individual);
+        act3.setTitulo("A3"); act3.setData("2025-09-12"); act3.setInicio("08:00"); act3.setFim("09:00"); act3.setCreatedBy(u);
+        activityRepository.save(act3);
+        Attendance att3 = new Attendance(); att3.setActivity(act3); att3.setUser(u); att3.setStatus(AttendanceStatus.pendente); att3.setModo(AttendanceMode.manual); att3.setCreatedAt("2025-09-12T09:00:00");
+        attendanceRepository.save(att3);
+    }
+
+    @Test
+    void timesheet_summary_and_pdf() throws Exception {
+        String json = mvc.perform(get("/api/v1/users/" + userId + "/timesheet")
+                        .param("from", "2025-09-01").param("to", "2025-09-30"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode node = om.readTree(json);
+        double horas = node.get("totalHoras").asDouble();
+        // 2h + 2.5h = 4.5h
+        assertThat(horas).isEqualTo(4.5);
+
+        mvc.perform(post("/api/v1/users/" + userId + "/timesheet/pdf")
+                        .param("from", "2025-09-01").param("to", "2025-09-30"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("application/pdf"));
+    }
+
+    @Test
+    void reports_hours_by_user_and_pending() throws Exception {
+        String hrs = mvc.perform(get("/api/v1/reports/hours-by-user")
+                        .param("gtId", String.valueOf(gtId)).param("month", "2025-09"))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(hrs).contains("aluno@example.com");
+
+        String pend = mvc.perform(get("/api/v1/reports/pending-attendances")
+                        .param("gtId", String.valueOf(gtId)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+        assertThat(pend).contains("A3"); // response carries activity id; at least ensure presence exists
+    }
+}


### PR DESCRIPTION
Implements core reporting endpoints per SPEC:

- Timesheet
  - GET /api/v1/users/{userId}/timesheet?from&to → totalHoras, itens, flag horasInsuficientes
  - POST /api/v1/users/{userId}/timesheet/pdf → PDF export (OpenPDF)
- Reports
  - GET /api/v1/reports/hours-by-user?gtId&month
  - GET /api/v1/reports/pending-attendances?gtId

Also adds repository queries, services and a test suite (TimesheetReportsWebMvcTest).

Build & tests: ./backend/mvnw -DskipTests=false verify
