### PR TITLE
feat: JSON Export + Audit Logs

### DIFF
--- a/backend/src/main/java/com/petsaudedigital/backend/api/ExportController.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/api/ExportController.java
@@ -1,0 +1,146 @@
+package com.petsaudedigital.backend.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.petsaudedigital.backend.api.dto.ExportDtos;
+import com.petsaudedigital.backend.domain.*;
+import com.petsaudedigital.backend.repository.*;
+import com.petsaudedigital.backend.service.AuditService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+import java.util.*;
+
+@RestController
+@RequiredArgsConstructor
+public class ExportController {
+    private final ObjectMapper om;
+    private final ProjectRepository projectRepository;
+    private final AxisRepository axisRepository;
+    private final GtRepository gtRepository;
+    private final ActivityRepository activityRepository;
+    private final AttendanceRepository attendanceRepository;
+    private final UserGtRepository userGtRepository;
+    private final UserRepository userRepository;
+    private final ExportLogRepository exportLogRepository;
+    private final AuditService auditService;
+
+    @PostMapping("/api/v1/exports/json")
+    @PreAuthorize("@scope.has(authentication, 'exportar_dados', #req.scopeType, #req.scopeId)")
+    public ResponseEntity<ObjectNode> export(@RequestBody ExportDtos.Request req, Authentication auth) {
+        // Resolve GTs a exportar
+        Set<Long> gtIds = new HashSet<>(Optional.ofNullable(req.gtIds()).orElse(List.of()));
+        if (req.scopeType() != null && "GT".equals(req.scopeType()) && req.scopeId() != null) {
+            gtIds.add(req.scopeId());
+        }
+        List<Gt> gts = gtIds.isEmpty() ? gtRepository.findAll() : gtRepository.findAllById(gtIds);
+
+        // Montar estrutura meta
+        ObjectNode root = om.createObjectNode();
+        ObjectNode meta = root.putObject("meta");
+        meta.put("schema_version", Optional.ofNullable(req.schemaVersion()).orElse("1.2.0"));
+        meta.put("generated_at", Instant.now().toString());
+        if (auth != null) {
+            userRepository.findByEmail(auth.getName()).ifPresent(u -> {
+                ObjectNode by = meta.putObject("generated_by");
+                by.put("id", u.getId()); by.put("nome", u.getNome()); by.put("email", u.getEmail());
+            });
+        }
+        if (req.scopeType() != null) {
+            ObjectNode scope = meta.putObject("scope");
+            scope.put("type", req.scopeType());
+            if (req.scopeId() != null) scope.put("id", req.scopeId());
+        }
+        ObjectNode filters = meta.putObject("filters");
+        if (req.from() != null) filters.put("from", req.from());
+        if (req.to() != null) filters.put("to", req.to());
+        if (!gtIds.isEmpty()) {
+            ArrayNode arr = filters.putArray("gt_ids");
+            gtIds.forEach(arr::add);
+        }
+
+        // Organizar por eixo
+        ArrayNode eixos = root.putArray("eixos");
+        Map<Long, ObjectNode> axisJsonById = new HashMap<>();
+        for (Gt gt : gts) {
+            Axis axis = gt.getAxis();
+            ObjectNode axisNode = axisJsonById.computeIfAbsent(axis.getId(), id -> {
+                ObjectNode an = om.createObjectNode();
+                an.put("id", axis.getId());
+                an.put("nome", axis.getNome());
+                an.set("gts", om.createArrayNode());
+                eixos.add(an);
+                return an;
+            });
+            ArrayNode axisGts = (ArrayNode) axisNode.get("gts");
+            ObjectNode gtNode = om.createObjectNode();
+            gtNode.put("id", gt.getId());
+            gtNode.put("nome", gt.getNome());
+            // subgrupos (simplificado)
+            gtNode.set("subgrupos", om.createArrayNode());
+
+            // usuarios do GT
+            ArrayNode usuarios = gtNode.putArray("usuarios");
+            userGtRepository.findAll().stream()
+                    .filter(ug -> ug.getGt().getId().equals(gt.getId()))
+                    .map(UserGt::getUser)
+                    .distinct()
+                    .forEach(u -> {
+                        ObjectNode un = om.createObjectNode();
+                        un.put("id", u.getId());
+                        un.put("nome", u.getNome());
+                        un.put("email", u.getEmail());
+                        usuarios.add(un);
+                    });
+
+            // atividades no período
+            ArrayNode atividades = gtNode.putArray("atividades");
+            for (Activity a : activityRepository.findByGt(gt)) {
+                if (req.from() != null && a.getData().compareTo(req.from()) < 0) continue;
+                if (req.to() != null && a.getData().compareTo(req.to()) > 0) continue;
+                ObjectNode an = om.createObjectNode();
+                an.put("id", a.getId());
+                an.put("tipo", a.getTipo().name());
+                an.put("titulo", a.getTitulo());
+                an.put("data", a.getData());
+                an.put("inicio", a.getInicio());
+                an.put("fim", a.getFim());
+                ArrayNode presencas = an.putArray("presencas");
+                for (Attendance at : attendanceRepository.findByActivity(a)) {
+                    ObjectNode pn = om.createObjectNode();
+                    pn.put("user_id", at.getUser().getId());
+                    pn.put("status", at.getStatus().name());
+                    pn.put("modo", at.getModo().name());
+                    presencas.add(pn);
+                }
+                atividades.add(an);
+            }
+
+            axisGts.add(gtNode);
+        }
+
+        // Log de export
+        ExportLog log = new ExportLog();
+        if (auth != null) userRepository.findByEmail(auth.getName()).ifPresent(log::setActor);
+        log.setScopeType(req.scopeType());
+        log.setScopeId(req.scopeId());
+        log.setFiltersJson(om.createObjectNode()
+                .put("from", Optional.ofNullable(req.from()).orElse(""))
+                .put("to", Optional.ofNullable(req.to()).orElse(""))
+                .putPOJO("gt_ids", gtIds)
+                .toString());
+        log.setSchemaVersion(meta.get("schema_version").asText());
+        log.setCreatedAt(Instant.now().toString());
+        exportLogRepository.save(log);
+
+        auditService.log(auth, "export_json", "export", log.getId(), null);
+
+        return ResponseEntity.ok(root);
+    }
+}
+

--- a/backend/src/main/java/com/petsaudedigital/backend/api/dto/ExportDtos.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/api/dto/ExportDtos.java
@@ -1,0 +1,8 @@
+package com.petsaudedigital.backend.api.dto;
+
+import java.util.List;
+
+public class ExportDtos {
+    public record Request(String scopeType, Long scopeId, String from, String to, List<Long> gtIds, String schemaVersion) {}
+}
+

--- a/backend/src/main/java/com/petsaudedigital/backend/domain/AuditLog.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/domain/AuditLog.java
@@ -1,0 +1,28 @@
+package com.petsaudedigital.backend.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "audit_log")
+@Getter
+@Setter
+public class AuditLog {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "actor_id")
+    private User actor;
+
+    private String action;
+    private String entity;
+    @Column(name = "entity_id")
+    private Long entityId;
+    @Column(name = "payload_diff")
+    private String payloadDiff;
+    @Column(name = "created_at")
+    private String createdAt;
+}
+

--- a/backend/src/main/java/com/petsaudedigital/backend/domain/ExportLog.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/domain/ExportLog.java
@@ -1,0 +1,34 @@
+package com.petsaudedigital.backend.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "export_log")
+@Getter
+@Setter
+public class ExportLog {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "actor_id")
+    private User actor;
+
+    @Column(name = "scope_type")
+    private String scopeType; // GLOBAL|AXIS|GT
+
+    @Column(name = "scope_id")
+    private Long scopeId;
+
+    @Column(name = "filters_json")
+    private String filtersJson;
+
+    @Column(name = "schema_version")
+    private String schemaVersion;
+
+    @Column(name = "created_at")
+    private String createdAt;
+}
+

--- a/backend/src/main/java/com/petsaudedigital/backend/repository/AuditLogRepository.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/repository/AuditLogRepository.java
@@ -1,0 +1,7 @@
+package com.petsaudedigital.backend.repository;
+
+import com.petsaudedigital.backend.domain.AuditLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {}
+

--- a/backend/src/main/java/com/petsaudedigital/backend/repository/ExportLogRepository.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/repository/ExportLogRepository.java
@@ -1,0 +1,7 @@
+package com.petsaudedigital.backend.repository;
+
+import com.petsaudedigital.backend.domain.ExportLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExportLogRepository extends JpaRepository<ExportLog, Long> {}
+

--- a/backend/src/main/java/com/petsaudedigital/backend/service/AttendanceService.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/service/AttendanceService.java
@@ -21,6 +21,7 @@ public class AttendanceService {
     private final AttendanceRepository attendanceRepository;
     private final AttendanceValidationRepository attendanceValidationRepository;
     private final UserRepository userRepository;
+    private final AuditService auditService;
 
     @Transactional
     public void validate(Long attendanceId, Authentication auth) {
@@ -36,6 +37,7 @@ public class AttendanceService {
         av.setDecision(ValidationDecision.validar);
         av.setValidatedAt(Instant.now().toString());
         attendanceValidationRepository.save(av);
+        auditService.log(auth, "validate_attendance", "attendance", att.getId(), null);
     }
 
     @Transactional
@@ -52,5 +54,6 @@ public class AttendanceService {
         av.setDecision(ValidationDecision.rejeitar);
         av.setValidatedAt(Instant.now().toString());
         attendanceValidationRepository.save(av);
+        auditService.log(auth, "reject_attendance", "attendance", att.getId(), null);
     }
 }

--- a/backend/src/main/java/com/petsaudedigital/backend/service/AuditService.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/service/AuditService.java
@@ -1,0 +1,37 @@
+package com.petsaudedigital.backend.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.petsaudedigital.backend.domain.AuditLog;
+import com.petsaudedigital.backend.domain.User;
+import com.petsaudedigital.backend.repository.AuditLogRepository;
+import com.petsaudedigital.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class AuditService {
+    private final AuditLogRepository auditLogRepository;
+    private final UserRepository userRepository;
+    private final ObjectMapper om;
+
+    public void log(Authentication auth, String action, String entity, Long entityId, Object diff) {
+        AuditLog l = new AuditLog();
+        if (auth != null) {
+            userRepository.findByEmail(auth.getName()).ifPresent(l::setActor);
+        }
+        l.setAction(action);
+        l.setEntity(entity);
+        l.setEntityId(entityId);
+        if (diff != null) {
+            try { l.setPayloadDiff(om.writeValueAsString(diff)); } catch (JsonProcessingException ignored) {}
+        }
+        l.setCreatedAt(Instant.now().toString());
+        auditLogRepository.save(l);
+    }
+}
+

--- a/backend/src/main/java/com/petsaudedigital/backend/service/PermissionService.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/service/PermissionService.java
@@ -16,6 +16,7 @@ import java.time.Instant;
 public class PermissionService {
     private final UserPermissionRepository userPermissionRepository;
     private final UserRepository userRepository;
+    private final AuditService auditService;
 
     public void grant(Authentication authentication, PermissionDtos.Grant req) {
         User target = userRepository.findById(req.userId()).orElseThrow();
@@ -32,11 +33,12 @@ public class PermissionService {
         up.setGrantedAt(Instant.now().toString());
 
         userPermissionRepository.save(up);
+        auditService.log(authentication, "grant_permission", "user_permission", target.getId(), req);
     }
 
     public void revoke(PermissionDtos.Revoke req) {
         UserPermission.Id id = new UserPermission.Id(req.userId(), req.permission(), req.scopeType(), req.scopeId());
         userPermissionRepository.deleteById(id);
+        auditService.log(null, "revoke_permission", "user_permission", req.userId(), req);
     }
 }
-

--- a/backend/src/test/java/com/petsaudedigital/backend/api/ExportWebMvcTest.java
+++ b/backend/src/test/java/com/petsaudedigital/backend/api/ExportWebMvcTest.java
@@ -1,0 +1,81 @@
+package com.petsaudedigital.backend.api;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.petsaudedigital.backend.api.dto.ExportDtos;
+import com.petsaudedigital.backend.domain.*;
+import com.petsaudedigital.backend.domain.enums.ActivityType;
+import com.petsaudedigital.backend.domain.enums.AttendanceMode;
+import com.petsaudedigital.backend.domain.enums.AttendanceStatus;
+import com.petsaudedigital.backend.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ExportWebMvcTest {
+    @Autowired MockMvc mvc;
+    @Autowired ObjectMapper om;
+    @Autowired ProjectRepository projectRepository;
+    @Autowired AxisRepository axisRepository;
+    @Autowired GtRepository gtRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired ActivityRepository activityRepository;
+    @Autowired AttendanceRepository attendanceRepository;
+    @Autowired ExportLogRepository exportLogRepository;
+    @Autowired UserRoleRepository userRoleRepository;
+
+    Long gtId; Long userId;
+
+    @BeforeEach
+    void setup() {
+        attendanceRepository.deleteAll();
+        activityRepository.deleteAll();
+        gtRepository.deleteAll();
+        axisRepository.deleteAll();
+        projectRepository.deleteAll();
+        userRepository.deleteAll();
+        exportLogRepository.deleteAll();
+
+        User u = new User(); u.setNome("Maria"); u.setEmail("maria@example.com"); u.setPasswordHash("x"); userRepository.save(u); userId = u.getId();
+        UserRole ur = new UserRole(); ur.setUser(u); ur.setId(new UserRole.Id(userId, "coordenador_geral")); userRoleRepository.save(ur);
+        Project p = new Project(); p.setNome("P"); p.setDescricao("D"); p.setAtivo(1); p.setCreatedAt("2025-09-07T00:00:00"); projectRepository.save(p);
+        Axis a = new Axis(); a.setProject(p); a.setNome("Eixo"); a.setAtivo(1); axisRepository.save(a);
+        Gt gt = new Gt(); gt.setProject(p); gt.setAxis(a); gt.setNome("GT"); gt.setAtivo(1); gtRepository.save(gt); gtId = gt.getId();
+
+        Activity act = new Activity();
+        act.setProject(p); act.setGt(gt); act.setTipo(ActivityType.individual);
+        act.setTitulo("A"); act.setData("2025-09-05"); act.setInicio("09:00"); act.setFim("10:00"); act.setCreatedBy(u);
+        activityRepository.save(act);
+        Attendance att = new Attendance(); att.setActivity(act); att.setUser(u); att.setStatus(AttendanceStatus.validada); att.setModo(AttendanceMode.manual); att.setCreatedAt("2025-09-05T10:00:00");
+        attendanceRepository.save(att);
+    }
+
+    @Test
+    @WithMockUser(username = "maria@example.com", roles = {"coordenador_geral"})
+    void export_json_creates_log_and_returns_structure() throws Exception {
+        ExportDtos.Request req = new ExportDtos.Request("GT", gtId, "2025-09-01", "2025-09-30", java.util.List.of(gtId), "1.2.0");
+        String res = mvc.perform(post("/api/v1/exports/json")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        JsonNode node = om.readTree(res);
+        assertThat(node.get("meta").get("schema_version").asText()).isEqualTo("1.2.0");
+        assertThat(node.get("eixos").toString()).contains("GT");
+        assertThat(exportLogRepository.count()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
Implements JSON export endpoint and basic audit logging.

- POST /api/v1/exports/json (permission-checked via @scope.has):
  - Returns meta (schema_version, generated_at, generated_by, scope, filters)
  - Returns data grouped by eixos → gts → atividades → presenças (simplificado)
  - Logs request in export_log
- Audit logs: records events for export, permission grant/revoke, attendance validate/reject
- Adds JPA entities + repositories for audit_log and export_log
- Tests: ExportWebMvcTest covers the export flow and log creation

Build & tests: ./backend/mvnw -DskipTests=false verify
