### PR TITLE
feat: Manual attendances, activities filters, settings(min hours), audit endpoint

### DIFF
--- a/backend/src/main/java/com/petsaudedigital/backend/api/ActivitiesController.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/api/ActivitiesController.java
@@ -7,6 +7,7 @@ import com.petsaudedigital.backend.repository.ActivityRepository;
 import com.petsaudedigital.backend.repository.AttendanceRepository;
 import com.petsaudedigital.backend.service.ActivityService;
 import com.petsaudedigital.backend.service.AttendanceService;
+import com.petsaudedigital.backend.domain.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -41,6 +42,44 @@ public class ActivitiesController {
         List<com.petsaudedigital.backend.api.dto.AttendanceDtos.View> out = attendanceRepository.findByActivity(a)
                 .stream().map(com.petsaudedigital.backend.api.dto.AttendanceDtos.View::from).toList();
         return ResponseEntity.ok(out);
+    }
+
+    @GetMapping("/api/v1/gts/{gtId}/activities")
+    public ResponseEntity<List<Activity>> listByGt(@PathVariable Long gtId,
+                                                   @RequestParam(required = false) String from,
+                                                   @RequestParam(required = false) String to,
+                                                   @RequestParam(required = false) String tipo) {
+        return activityRepository.findById(gtId).map(a -> ResponseEntity.ok(List.of(a))).orElseGet(() -> {
+            // Fallback by querying repository (simplified by scanning all in repo)
+            List<Activity> all = activityRepository.findAll().stream()
+                    .filter(ac -> ac.getGt() != null && ac.getGt().getId().equals(gtId))
+                    .filter(ac -> from == null || ac.getData().compareTo(from) >= 0)
+                    .filter(ac -> to == null || ac.getData().compareTo(to) <= 0)
+                    .filter(ac -> tipo == null || ac.getTipo().name().equalsIgnoreCase(tipo))
+                    .toList();
+            return ResponseEntity.ok(all);
+        });
+    }
+
+    @PostMapping("/api/v1/activities/{activityId}/attendances")
+    @PreAuthorize("@scope.has(authentication, 'lancar_presenca_validada', 'GT', @scopeResolver.fromActivity(#activityId))")
+    public ResponseEntity<Attendance> addManualAttendance(@PathVariable Long activityId,
+                                                          @RequestParam Long userId,
+                                                          Authentication auth) {
+        Activity a = activityRepository.findById(activityId).orElseThrow();
+        User u = attendanceService.getUserRepository().findById(userId).orElseThrow();
+        var existing = attendanceRepository.findByActivityAndUser(a, u);
+        if (existing.isPresent()) {
+            return ResponseEntity.status(409).build();
+        }
+        Attendance att = attendanceService.createManual(a, u, auth);
+        return ResponseEntity.ok(att);
+    }
+
+    @DeleteMapping("/api/v1/attendances/{id}")
+    @PreAuthorize("@scope.has(authentication, 'exportar_dados', 'GT', @scopeResolver.fromAttendance(#id))")
+    public ResponseEntity<Void> deleteAttendance(@PathVariable Long id) {
+        return attendanceService.deleteIfPending(id) ? ResponseEntity.noContent().build() : ResponseEntity.status(400).build();
     }
 
     @PatchMapping("/api/v1/activities/{id}")

--- a/backend/src/main/java/com/petsaudedigital/backend/api/AuditController.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/api/AuditController.java
@@ -1,0 +1,23 @@
+package com.petsaudedigital.backend.api;
+
+import com.petsaudedigital.backend.domain.AuditLog;
+import com.petsaudedigital.backend.repository.AuditLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class AuditController {
+    private final AuditLogRepository repo;
+
+    @GetMapping("/api/v1/audit")
+    @PreAuthorize("@scope.has(authentication, 'exportar_dados', 'GLOBAL', null)")
+    public ResponseEntity<List<AuditLog>> list() {
+        return ResponseEntity.ok(repo.findAll());
+    }
+}
+

--- a/backend/src/main/java/com/petsaudedigital/backend/domain/SystemSetting.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/domain/SystemSetting.java
@@ -1,0 +1,33 @@
+package com.petsaudedigital.backend.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "system_settings")
+@Getter
+@Setter
+public class SystemSetting {
+    @EmbeddedId
+    private Id id;
+    @Column(name = "value")
+    private String value;
+
+    @Embeddable
+    @Getter
+    @Setter
+    public static class Id implements java.io.Serializable {
+        @Column(name = "project_id")
+        private Long projectId;
+        @Column(name = "key")
+        private String key;
+        @Column(name = "scope_type")
+        private String scopeType; // GLOBAL|AXIS|GT
+        @Column(name = "scope_id")
+        private Long scopeId;
+        @Column(name = "effective_from")
+        private String effectiveFrom; // ISO date
+    }
+}
+

--- a/backend/src/main/java/com/petsaudedigital/backend/repository/SystemSettingRepository.java
+++ b/backend/src/main/java/com/petsaudedigital/backend/repository/SystemSettingRepository.java
@@ -1,0 +1,15 @@
+package com.petsaudedigital.backend.repository;
+
+import com.petsaudedigital.backend.domain.SystemSetting;
+import com.petsaudedigital.backend.domain.SystemSetting.Id;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface SystemSettingRepository extends JpaRepository<SystemSetting, Id> {
+    @Query("select s from SystemSetting s where s.id.key = :key and (s.id.scopeType = :scopeType or :scopeType is null) and (s.id.scopeId = :scopeId or :scopeId is null)")
+    List<SystemSetting> findByKeyAndScope(@Param("key") String key, @Param("scopeType") String scopeType, @Param("scopeId") Long scopeId);
+}
+


### PR DESCRIPTION
Adds:
- POST /api/v1/activities/{activityId}/attendances (manual create, guarded by scope permission), DELETE /api/v1/attendances/{id} (if pending)
- GET /api/v1/gts/{gtId}/activities?from&to&tipo
- system_settings entity/repo + Timesheet uses min_monthly_hours by scope (GT>AXIS>GLOBAL), fallback 32h
- GET /api/v1/audit (limited to Coordenador Geral)

Tests compile locally; existing suite remains green during development.
